### PR TITLE
fix: maxAmountWood uses wrong field (MRF instead of MRW)

### DIFF
--- a/protocols.js
+++ b/protocols.js
@@ -386,7 +386,7 @@ const GetProductionData = e => ({
 
     maxAmountFood: Number(e.MRF),
     maxAmountStone: Number(e.MRS),
-    maxAmountWood: Number(e.MRF),
+    maxAmountWood: Number(e.MRW),
     maxAmountCoal: Number(e.MRC),
     maxAmountIron: Number(e.MRI),
     maxAmountOil: Number(e.MRO),


### PR DESCRIPTION
## Problem

`maxAmountWood` was set to `e.MRF` (food max) instead of `e.MRW` (wood max) on line 389.

This caused wood capacity to report food capacity (~800k instead of ~101k), preventing auto-donate plugins from correctly detecting when wood is full.

## Fix

Changed `Number(e.MRF)` to `Number(e.MRW)` — the correct field for wood max resource capacity.

## Impact

Plugins using `getProductionData.maxAmountWood` will now get accurate wood capacity values instead of food capacity values.